### PR TITLE
fix(auth): [#31] update pw fix

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,15 +7,20 @@ interface ApiError {
   status: string;
 }
 
-const baseFetch: typeof fetch = async (url, options) => {
+const baseFetch: typeof fetch = async (url, options = {}) => {
+  const { next, ...restOptions } = options as RequestInit & {
+    next?: { revalidate?: number; cache?: string };
+  };
+
   const response = await fetch(`${API_BASE_URL}${url}`, {
     headers: {
       'Content-Type': 'application/json',
+      ...(restOptions.headers || {}),
     },
-    ...options,
+    ...restOptions,
     next: {
-      revalidate: 3600, // revalidate at most every hour
-      ...options?.next,
+      cache: next?.cache || 'no-store',
+      ...next,
     },
   });
 

--- a/src/services/auth/actions/register.ts
+++ b/src/services/auth/actions/register.ts
@@ -26,16 +26,18 @@ export const register = async (values: z.infer<typeof RegisterSchema>) => {
   const payload = { email, password, privacyConsent, role: 'ADMIN' };
 
   try {
-    const response = await api.post<RegisterResponse>(
+    const response = await api.post<{ value: RegisterResponse }>(
       '/Auth/register',
       payload
     );
 
-    if (response.status !== 'Success') {
-      return { error: response.message || 'Failed to register user.' };
+    const { value } = response;
+
+    if (value.status !== 'Success') {
+      return { error: value.message || 'Failed to register user.' };
     }
 
-    return { success: response.message || 'Registration successful!' };
+    return { success: value.message || 'Registration successful!' };
   } catch (error: unknown) {
     console.error('Error during registration:', error);
     return {


### PR DESCRIPTION
## Set Default Cache Behavior in API Utility to `no-store`

## Description

Simplified the `api.ts` utility by setting the default caching behavior to `no-store` if not explicitly specified.

## Related Issue

Fixes #31

## Changes

- Defaulted the `cache` option to `no-store` in `baseFetch`.
- Ensured developers can override the caching behavior if needed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] New and existing tests pass locally with my changes
- [x] I have checked for merge conflicts